### PR TITLE
Loosen text upper bound so we can support GHC 8.4.1

### DIFF
--- a/sqlite-simple-errors.cabal
+++ b/sqlite-simple-errors.cabal
@@ -21,7 +21,7 @@ library
                      , Database.SQLite.SimpleErrors.Types
   build-depends:       base          >= 4.6   && < 5
                      , sqlite-simple >= 0.4.9 && < 0.5.0
-                     , text          >= 1.2   && < 1.2.3
+                     , text          >= 1.2   && < 1.2.4
                      , parsec        >= 3.1.9 && < 3.2
   default-language:    Haskell2010
 
@@ -34,7 +34,7 @@ test-suite sqlite-simple-errors-test
   build-depends:       base
                      , sqlite-simple-errors
                      , sqlite-simple >= 0.4.9 && < 0.5.0
-                     , text          >= 1.2   && < 1.2.3
+                     , text          >= 1.2   && < 1.2.4
                      , mtl           >= 2.1   && < 2.3
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
minor shift in upper bounds for the `text` package so that we can support GHC 8.4.1. :)