### PR TITLE
Make constraintParser never fail

### DIFF
--- a/src/Database/SQLite/SimpleErrors/Parser.hs
+++ b/src/Database/SQLite/SimpleErrors/Parser.hs
@@ -41,12 +41,16 @@ parseConstraintNoDetails :: String -> Constraint -> SQLiteParser
 parseConstraintNoDetails n c =
   constraintNameOnly n >> return (SQLConstraintError c Text.empty)
 
+parseOtherConstraint :: SQLiteParser
+parseOtherConstraint = SQLConstraintError UnknownConstraintError <$> getRest
+
 constraintParser :: Parsec Text () SQLiteResponse
 constraintParser =
   parseConstraintNoDetails "FOREIGN KEY" ForeignKey <|>
   parseConstraint "NOT NULL"    NotNull             <|>
   parseConstraint "UNIQUE"      Unique              <|>
-  parseConstraint "CHECK"       Check
+  parseConstraint "CHECK"       Check               <|>
+  parseOtherConstraint
 
 parseError :: SQLError -> SQLiteResponse
 parseError e@SQLError{sqlErrorDetails = details} =

--- a/src/Database/SQLite/SimpleErrors/Types.hs
+++ b/src/Database/SQLite/SimpleErrors/Types.hs
@@ -22,6 +22,7 @@ data Constraint = NotNull
                 | ForeignKey
                 | Unique
                 | Check
+                | UnknownConstraintError
   deriving (Show, Eq)
 
 -- | SQLiteResponse is a wrapper around the different kinds of errors that can


### PR DESCRIPTION
A race condition at the dependencies of `sqlite-simple-errors` can make exceptions be completely wrong when many threads use the same db connection (more https://github.com/IreneKnapp/direct-sqlite/issues/77).  Take a look at the following example

```
import Database.SQLite.Simple
import Database.SQLite.SimpleErrors
import Database.SQLite.SimpleErrors.Types

createPeopleTableSQL :: Query
createPeopleTableSQL =
  "CREATE TABLE People (name varchar(50) NOT NULL UNIQUE               \
  \                    ,id   int         NOT NULL CHECK(id >= 0)              \
  \                    );"

testErrors :: IO ()
testErrors = do
    conn <- open ":memory:"
    execute_ conn createPeopleTableSQL
    execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( ("Ann", 0) :: (Text, Int) )
    forkIO $ thread0 conn
    forkIO $ thread1 conn
    threadDelay 100000

thread0 :: Connection -> IO ()
thread0 conn = do
    forM_ [1..10000] $ \n -> do
        result1 <- runDBAction $ execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( ("Ann", n) :: (Text, Int) )
        case result1 of
            Left (SQLConstraintError Unique "People.name") -> return ()
            _ -> (error $ ("thread 0 trial " <> show n <> " got: " :: String) <> show result1)

thread1 :: Connection -> IO ()
thread1 conn = do
    forM_ [1..10000] $ \n -> do
        _ <- runDBAction $ execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( (show n, -1) :: (Text, Int) )
        return ()
```
When I run it I get many unexpected results like:
- thread 0 trial 11 got: Left (SQLOtherError SQLite3 returned ErrorConstraint while attempting to perform step: not an error)
CallStack (from HasCallStack):
- thread 0 trial 12 got: Left (SQLConstraintError Check "People")
CallStack (from HasCallStack):

At the first case, the parsers fail to parse the constraint error, because of the wrong details given "not an error". At the second we get a Check error, which is what the other thread would except! This happens because of the race condition.

`sqlite-simple-errors` has unfortunately no control over what errors it can get. Fortunately it is only the details of the error that are prone to the race condition and not the main error. That's why at the examples above, `sqlite-simple` always reports `ErrorConstraint`. However `sqlite-simple-error` reports an `SQLOtherError` (see first example) because the details are wrong. This pr slightly improves the parsers, so that the main error is correct and the contsraint parser never fails.

After the fix an application that runs in multithreading, can do the following:
```
thread0 :: Connection -> IO ()
thread0 conn = do
    forM_ [1..10000] $ \n -> do
        result1 <- runDBAction $ execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( ("Ann", n) :: (Text, Int) )
        case result1 of
            Left (SQLConstraintError _ _) -> return ()
            _ -> (error $ ("thread 0 trial " <> show n <> " got: " :: String) <> show result1)

thread1 :: --- same as above
```
and always succeed. Before the fix this fails, because the parsers fail to reliably parse the `SQLConstraintError`. On the other hand an application that known that it runs in single thread can get reliably the whole message:
```
thread0 :: Connection -> IO ()
thread0 conn = do
    forM_ [1..10000] $ \n -> do
        result1 <- runDBAction $ execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( ("Ann", n) :: (Text, Int) )
        case result1 of
            Left (SQLConstraintError Unique "People.name") -> return ()
            _ -> (error $ ("thread 0 trial " <> show n <> " got: " :: String) <> show result1)

thread1 :: Connection -> IO ()
thread1 conn = do
    forM_ [1..10000] $ \n -> do
        return ()
```
As a note: other errors are not affected: For example if I do
```
thread0 :: Connection -> IO ()
thread0 conn = do
    forM_ [1..10000] $ \n -> do
        result1 <- runDBAction $ execute conn "INSERT INTO People1 (name, id) VALUES (?, ?)" ( ("Ann", n) :: (Text, Int) )
        case result1 of
            Left (SQLConstraintError _ _) -> return ()
            _ -> (error $ ("thread 0 trial " <> show n <> " got: " :: String) <> show result1)

thread1 :: Connection -> IO ()
thread1 conn = do
    forM_ [1..10000] $ \n -> do
        _ <- runDBAction $ execute conn "INSERT INTO People (name, id) VALUES (?, ?)" ( (show n, -1) :: (Text, Int) )
        return ()
```
(notice People1 mispell) I get

main: thread 0 trial 1 got: Left (SQLOtherError SQLite3 returned ErrorError while attempting to perform prepare "INSERT INTO People1 (name, id) VALUES (?, ?)": no such table: People1)
CallStack (from HasCallStack):
