### PR TITLE
Relax version bounds on `text`

### DIFF
--- a/sqlite-simple-errors.cabal
+++ b/sqlite-simple-errors.cabal
@@ -21,7 +21,7 @@ library
                      , Database.SQLite.SimpleErrors.Types
   build-depends:       base          >= 4.6   && < 5
                      , sqlite-simple >= 0.4.9 && < 0.5.0
-                     , text          >= 1.2   && < 1.2.4
+                     , text          >= 1.2   && < 1.3
                      , parsec        >= 3.1.9 && < 3.2
   default-language:    Haskell2010
 
@@ -34,7 +34,7 @@ test-suite sqlite-simple-errors-test
   build-depends:       base
                      , sqlite-simple-errors
                      , sqlite-simple >= 0.4.9 && < 0.5.0
-                     , text          >= 1.2   && < 1.2.4
+                     , text          >= 1.2   && < 1.3
                      , mtl           >= 2.1   && < 2.3
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
The previous fix for this was too specific, and is already out of date.